### PR TITLE
add comments to jshint rules

### DIFF
--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -3,7 +3,7 @@
  *
  * Forked from Airbnb JSHint settings.
  *
- * @version 0.4.0
+ * @version 0.4.0s
  * @see http://www.jshint.com/docs/
  * @see https://github.com/airbnb/javascript
  */
@@ -21,16 +21,6 @@
 
   // Define globals exposed by Node.js.
   "node": true,
-
-  /*
-   * TABS AND QUOTES
-   * ==================
-   */
-  // Enforce tab width of 2 spaces.
-  "indent": 2,
-
-  // Enforce use of single quotation marks for strings.
-  "quotmark": "single",
 
   /*
    * ENFORCING OPTIONS
@@ -55,10 +45,6 @@
   // assignments in cases where comparisons are expected
   "boss": true,
 
-  // Force all variable names to use either camelCase style
-  // or UPPER_CASE with underscores.
-  "camelcase": true,
-
   // Prohibit use of == and != in favor of === and !==.
   "eqeqeq": true,
 
@@ -79,10 +65,6 @@
 
   // Warn when variables are defined but never used.
   "unused": true,
-
-  // do not complain for lack of 'use strict';
-  "globalstrict": false,
-  "strict": false,
 
   // suppress object dot notation warnings, we know what we're doing
   "sub": true,

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -22,6 +22,16 @@
   "node": true,
 
   /*
+   * TABS AND QUOTES
+   * ==================
+   */
+  // Enforce tab width of 2 spaces.
+  "indent": 2,
+
+  // Enforce use of single quotation marks for strings.
+  "quotmark": "single",
+
+  /*
    * ENFORCING OPTIONS
    * =================
    */
@@ -54,17 +64,11 @@
   // Suppress warnings about == null comparisons.
   "eqnull": true,
 
-  // Enforce tab width of 2 spaces.
-  "indent": 2,
-
   // Prohibit use of a variable before it is defined.
   "latedef": true,
 
   // Require capitalized names for constructor functions.
   "newcap": true,
-
-  // Enforce use of single quotation marks for strings.
-  "quotmark": "single",
 
   // Prohibit trailing whitespace.
   "trailing": true,

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -1,10 +1,11 @@
 /**
  * Project specific jshint linting options.
  *
- * Forked of Airbnb JSHint settings.
+ * Forked from Airbnb JSHint settings.
  *
  * @version 0.4.0
- * @see     http://www.jshint.com/docs/
+ * @see http://www.jshint.com/docs/
+ * @see https://github.com/airbnb/javascript
  */
 {
   /*

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -1,23 +1,102 @@
+/**
+ * Project specific jshint linting options.
+ *
+ * Forked of Airbnb JSHint settings.
+ *
+ * @version 0.4.0
+ * @see     http://www.jshint.com/docs/
+ */
 {
-  "curly": true,
-  "eqeqeq": true,
-  "immed": true,
-  "latedef": true,
-  "newcap": true,
-  "noarg": true,
-  "sub": true,
-  "undef": true,
-  "unused": true,
-  "boss": true,
-  "eqnull": true,
+  /*
+   * ENVIRONMENTS
+   * =================
+   */
+
+  // Define globals exposed by modern browsers.
+  "browser": false,
+
+  // Define globals exposed by jQuery.
+  "jquery": false,
+
+  // Define globals exposed by Node.js.
   "node": true,
-  "globals"   : {
-      /* MOCHA */
-      "suite": false,
-      "test": false,
-      "before": false,
-      "beforeEach": false,
-      "after": false,
-      "afterEach": false
-    }
+
+  /*
+   * ENFORCING OPTIONS
+   * =================
+   */
+
+  // This option requires you to always put curly braces
+  // around blocks in loops and conditionals.
+  "curly": true,
+
+  // This option prohibits the use of immediate function
+  // invocations without wrapping them in parentheses.
+  "immed": true,
+
+  // This option prohibits the use of arguments.caller
+  // and arguments.callee. Both .caller and .callee make
+  // quite a few optimizations impossible so they were
+  // deprecated in future versions of JavaScript.
+  "noarg": true,
+
+  // This option suppresses warnings about the use of
+  // assignments in cases where comparisons are expected
+  "boss": true,
+
+  // Force all variable names to use either camelCase style
+  // or UPPER_CASE with underscores.
+  "camelcase": true,
+
+  // Prohibit use of == and != in favor of === and !==.
+  "eqeqeq": true,
+
+  // Suppress warnings about == null comparisons.
+  "eqnull": true,
+
+  // Enforce tab width of 2 spaces.
+  "indent": 2,
+
+  // Prohibit use of a variable before it is defined.
+  "latedef": true,
+
+  // Require capitalized names for constructor functions.
+  "newcap": true,
+
+  // Enforce use of single quotation marks for strings.
+  "quotmark": "single",
+
+  // Prohibit trailing whitespace.
+  "trailing": true,
+
+  // Prohibit use of explicitly undeclared variables.
+  "undef": true,
+
+  // Warn when variables are defined but never used.
+  "unused": true,
+
+  // do not complain for lack of 'use strict';
+  "globalstrict": false,
+  "strict": false,
+
+  // suppress object dot notation warnings, we know what we're doing
+  "sub": true,
+
+  /**
+   * PROJECT GLOBALS
+   * ================
+   *
+   */
+  "predef": [
+    /* MOCHA */
+    "suite": false,
+    "test": false,
+    "before": false,
+    "beforeEach": false,
+    "after": false,
+    "afterEach": false
+    "setup",
+    "teardown",
+    "assert"
+  ]
 }


### PR DESCRIPTION
This PR adds sensible comments to the `.jshintrc` file, retains every rule that previously existed and adds the following new rules:

```
  // Force all variable names to use either camelCase style
  // or UPPER_CASE with underscores.
  "camelcase": true,
  // Prohibit trailing whitespace.
  "trailing": true,
```

Additionally adds the following two opinionated rules, but under a clear banner to easily be configured. Opinions definitely diverge here but the rules have to be there for developers to change.

```
  // Enforce tab width of 2 spaces.
  "indent": 2,
  // Enforce use of single quotation marks for strings.
  "quotmark": "single",
```

Finally, two more rules were added related to not warn for the lack of `"use strict"`. I understand if you do not wish this be included.

```
  // do not complain for lack of 'use strict';
  "globalstrict": false,
  "strict": false,
```
